### PR TITLE
Werk release-aliascontracttest bij

### DIFF
--- a/scripts/tests/test_pr_test_firmware_workflows.py
+++ b/scripts/tests/test_pr_test_firmware_workflows.py
@@ -182,7 +182,7 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
             self.assertTrue((repo_root / "dist/openquatt-test.firmware.ota.bin.md5").is_file())
             self.assertTrue((repo_root / "dist/pr-firmware.json").is_file())
 
-    def test_release_aliases_are_byte_identical_and_get_matching_manifests(self) -> None:
+    def test_release_aliases_get_compatibility_manifests_without_duplicate_binaries(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)
             artifact_dir = repo_root / "dist/openquatt-test"
@@ -209,6 +209,17 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
                 mock.patch.object(build_targets, "REPO_ROOT", repo_root),
                 mock.patch.object(build_targets, "TARGETS_FILE", targets_file),
             ):
+                target = build_targets.load_targets()[0]
+                self.assertEqual(
+                    [
+                        "openquatt-test.firmware.ota.bin",
+                        "openquatt-test.firmware.factory.bin",
+                        "openquatt-test-ota.manifest.json",
+                        "openquatt-test-wifi-ota.manifest.json",
+                        "openquatt-test-eth-ota.manifest.json",
+                    ],
+                    build_targets.release_asset_names(target),
+                )
                 build_targets.prepare_release_assets(
                     "v1.2.3",
                     "https://example.invalid/download",
@@ -217,22 +228,35 @@ class PrTestFirmwareWorkflowTests(unittest.TestCase):
 
             canonical_ota = repo_root / "dist/openquatt-test.firmware.ota.bin"
             canonical_factory = repo_root / "dist/openquatt-test.firmware.factory.bin"
+            self.assertEqual(b"ota-firmware", canonical_ota.read_bytes())
+            self.assertEqual(b"factory-firmware", canonical_factory.read_bytes())
+
+            manifests = {
+                name: json.loads((repo_root / name).read_text(encoding="utf-8"))
+                for name in (
+                    "openquatt-test-ota.manifest.json",
+                    "openquatt-test-wifi-ota.manifest.json",
+                    "openquatt-test-eth-ota.manifest.json",
+                )
+            }
+            expected_ota_path = "https://example.invalid/download/openquatt-test.firmware.ota.bin"
+            expected_ota_md5 = build_targets.md5sum(canonical_ota)
+            for manifest in manifests.values():
+                self.assertEqual(expected_ota_path, manifest["builds"][0]["ota"]["path"])
+                self.assertEqual(expected_ota_md5, manifest["builds"][0]["ota"]["md5"])
+
+            self.assertEqual("Test target", manifests["openquatt-test-ota.manifest.json"]["name"])
             for alias in ("openquatt-test-wifi", "openquatt-test-eth"):
                 alias_ota = repo_root / f"dist/{alias}.firmware.ota.bin"
                 alias_factory = repo_root / f"dist/{alias}.firmware.factory.bin"
-                self.assertEqual(canonical_ota.read_bytes(), alias_ota.read_bytes())
-                self.assertEqual(canonical_factory.read_bytes(), alias_factory.read_bytes())
+                self.assertFalse(alias_ota.exists())
+                self.assertFalse(alias_factory.exists())
 
-                manifest = json.loads(
-                    (repo_root / f"{alias}-ota.manifest.json").read_text(encoding="utf-8")
-                )
-                self.assertTrue(
-                    manifest["builds"][0]["ota"]["path"].endswith(
-                        f"/{alias}.firmware.ota.bin"
-                    )
-                )
                 expected_connection = "Wi-Fi" if alias.endswith("-wifi") else "Ethernet"
-                self.assertEqual(f"Test target {expected_connection}", manifest["name"])
+                self.assertEqual(
+                    f"Test target {expected_connection}",
+                    manifests[f"{alias}-ota.manifest.json"]["name"],
+                )
 
     def test_pr_aliases_keep_legacy_connection_catalog_entries(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
# Wat verandert deze PR?

- Brengt de verouderde release-aliastest in lijn met het huidige releasecontract: één canonieke OTA- en factory-binary per Q-topologie, plus canonical/Wi-Fi/Ethernet-compatibilitymanifests.
- Controleert dat alle drie manifests naar dezelfde canonieke OTA en MD5 verwijzen, met behoud van de juiste displaynamen.
- Dekt ook de exacte `release_asset_names()`-whitelist waarmee onverwachte `dev-latest`-assets worden opgeschoond.

## Type

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] UI/config
- [ ] Control/platform
- [x] Tooling/generated
- [ ] Anders

## Impact

- [x] Geen runtime/control gedragswijziging bedoeld
- [ ] Runtime/control gedrag gewijzigd
- [ ] User-facing entities/configuratie gewijzigd
- [ ] Hardware/Modbus/actuator/safety/thermal/boiler/flow geraakt
- [ ] Interne heap/PSRAM/task-stacks/netwerkallocaties geraakt

Toelichting:

Alleen een Python-contracttest verandert. Productiecode, releasegeneratie en PR-testfirmware blijven ongewijzigd.

## Achtergrond

Het huidige `dev` publiceert bewust geen dubbele Wi-Fi/Ethernet-binaries meer; compatibilitymanifests verwijzen naar de canonieke binary. De oude test probeerde de verwijderde alias-binaries nog byte-voor-byte te lezen en maakte daardoor de volledige Python-suite rood. De actuele `dev-latest`-assetset en `scripts/build_targets.py` volgen wel het bedoelde contract.

De complete diff is gecontroleerd op release- versus PR-testassetgedrag, manifest-pad/MD5, displaynamen, afwezigheid van alias-binaries en de prune-whitelist. Een afzonderlijke koude review vond geen blockers. De extra 24 testregels zijn expliciete regressiedekking; er verandert geen firmware-YAML of C++.

## Documentatie

Kies exact één optie:

- [ ] Documentatie bijgewerkt voor de gebruikersgerichte wijziging
- [x] Geen documentatiewijziging nodig

Docs-impact motivatie:

Geen gebruikersgericht releasegedrag verandert; de test wordt hersteld naar het reeds geldende en gepubliceerde contract.

## Validatie

- `python3 -m unittest scripts.tests.test_pr_test_firmware_workflows.PrTestFirmwareWorkflowTests.test_release_aliases_get_compatibility_manifests_without_duplicate_binaries` — groen
- `npm run check:python-contracts` — groen (130 tests)
- `git diff --check` — groen
- Afzonderlijke koude diff-review — blocker-vrij

- [ ] Geheugenimpact gemeten op representatieve hardware
- [x] Geen runtime-geheugenimpact

Heap/stack-impact:

Test-only wijziging; firmware, runtime en buildoutput veranderen niet.
